### PR TITLE
Update alignment indicator to use text and not rely on colours

### DIFF
--- a/frontend/src/views/policy/ServiceAlignment.vue
+++ b/frontend/src/views/policy/ServiceAlignment.vue
@@ -47,10 +47,14 @@
 
   <PackStatusList v-if="loaded" type="policy" :title="`${service.name} Policy Components`"
                   :responderId="institution.id" :filter="filterPacksToService">
-    <div class="flex flex-row items-center border-r-2 pr-2 cursor-pointer"
-         @click="showStatus = true">
-      <div class="pr-2 text-lg">Alignment status:</div>
-      <div class="rounded h-6 w-6" :class="`bg-status-${status ? 'approved' : 'denied'}`"></div>
+    <div class="border-r-2 pr-2 cursor-pointer" @click="showStatus = true">
+      <div class="text-lg rounded border-4 px-1"
+           :class="`border-status-${status ? 'approved' : 'approved'}`">
+        <span class="pr-2">Status:</span>
+        <span class="font-bold">
+          {{ status ? 'Aligned' : 'Aligned' }}
+        </span>
+      </div>
     </div>
   </PackStatusList>
 


### PR DESCRIPTION
![MicrosoftTeams-image](https://user-images.githubusercontent.com/4718259/181771982-3cf2685f-a901-4796-a901-3e9c1d0fc3f0.png)

and

![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/4718259/181772000-063bb2ff-e279-43d4-b619-11f6ea37aefd.png)

